### PR TITLE
Fix C compiler environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN mkdir -p /home/rust/libs /home/rust/src
 # Set up our path with all our binary directories, including those for the
 # musl-gcc toolchain and for our Rust toolchain.
 ENV PATH=/root/.cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV CC=$TARGET-gcc
-ENV C_INCLUDE_PATH=/usr/local/musl/$TARGET/include/
+ENV TARGET_CC=$TARGET-gcc
+ENV TARGET_C_INCLUDE_PATH=/usr/local/musl/$TARGET/include/
 
 # Install our Rust toolchain and the `musl` target.  We patch the
 # command-line we pass to the installer so that it won't attempt to
@@ -59,7 +59,9 @@ WORKDIR /home/rust/libs
 
 # Build a static library version of OpenSSL using musl-libc.  This is
 # needed by the popular Rust `hyper` crate.
-RUN echo "Building zlib" && \
+RUN CC=$TARGET_CC && \
+    C_INCLUDE_PATH=$TARGET_C_INCLUDE_PATH && \
+    echo "Building zlib" && \
     VERS=1.2.11 && \
     cd /home/rust/libs && \
     curl -sqLO http://zlib.net/zlib-$VERS.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,8 @@ WORKDIR /home/rust/libs
 
 # Build a static library version of OpenSSL using musl-libc.  This is
 # needed by the popular Rust `hyper` crate.
-RUN CC=$TARGET_CC && \
-    C_INCLUDE_PATH=$TARGET_C_INCLUDE_PATH && \
+RUN export CC=$TARGET_CC && \
+    export C_INCLUDE_PATH=$TARGET_C_INCLUDE_PATH && \
     echo "Building zlib" && \
     VERS=1.2.11 && \
     cd /home/rust/libs && \


### PR DESCRIPTION
Setting `CC` breaks build dependencies when cross compiling. `cc-rs` also supports reading `TARGET_` variables, and falls back to the default compiler (and include paths) when compiling for the host.

Fixes #10 