### PR TITLE
Persist TARGET value in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ARG TOOLCHAIN=stable
 ARG TARGET=x86_64-unknown-linux-musl
 ARG OPENSSL_ARCH=linux-x86_64
 
+ENV RUST_MUSL_CROSS_TARGET=$TARGET
+
 # Make sure we have basic dev tools for building C libraries.  Our goal
 # here is to support the musl-libc builds and Cargo builds needed for a
 # large selection of the most popular crates.


### PR DESCRIPTION
Hi @messense, many thanks for the useful images!

I think it would be useful to persist the image's TARGET in the image itself, so there's no need to use some ugly workarounds (path parsing, reading from config files, etc.) to get the TARGET value.

The reason for picking a different variable name (`RUST_MUSL_CROSS_TARGET`) is to avoid possible collisions and unwanted side-effects.